### PR TITLE
Listing routing

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,14 +1,16 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { LoginPage } from "./pages/LoginPage";
 import { HomePage } from "./pages/HomePage";
+import { ListingPage } from "./pages/ListingPage";
 
 export const AppRouter = () => {
-  return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/Login" element={<LoginPage />} />
-      </Routes>
-    </Router>
-  );
+    return (
+        <Router>
+            <Routes>
+                <Route path="/" element={<HomePage />} />
+                <Route path="/login" element={<LoginPage />} />
+                <Route path="/listing/:listingId" element={<ListingPage />} />
+            </Routes>
+        </Router>
+    );
 };

--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -3,21 +3,21 @@ import { Button } from "react-bootstrap";
 import { Link } from "react-router-dom";
 
 export function LoginButton(): JSX.Element {
-  return (
-    <span>
-      <Link to={"/Login"}>
-        <Button
-          style={{
-            height: "50px",
-            width: "100px",
-            fontSize: "24px",
-            marginLeft: "900px",
-            marginBottom: "750px",
-          }}
-        >
-          Login
-        </Button>
-      </Link>
-    </span>
-  );
+    return (
+        <span>
+            <Link to={"/login"}>
+                <Button
+                    style={{
+                        height: "50px",
+                        width: "100px",
+                        fontSize: "24px",
+                        marginLeft: "900px",
+                        marginBottom: "750px",
+                    }}
+                >
+                    Login
+                </Button>
+            </Link>
+        </span>
+    );
 }

--- a/src/data/job_listing.tsx
+++ b/src/data/job_listing.tsx
@@ -1,13 +1,18 @@
-export type JobCriteriaType = "Location" | "Employment Type" | "Seniority" | "Industry";
+export type JobCriteriaType =
+    | "Location"
+    | "Employment Type"
+    | "Seniority"
+    | "Industry";
 
 export interface JobCriteriaItem {
-    field: JobCriteriaType,
-    value: string
+    field: JobCriteriaType;
+    value: string;
 }
 
 export interface JobListing {
-    company: string,
-    title: string,
-    description: string,
-    criteria: JobCriteriaItem[]
+    id: number;
+    company: string;
+    title: string;
+    description: string;
+    criteria: JobCriteriaItem[];
 }

--- a/src/dummy/job_listing.tsx
+++ b/src/dummy/job_listing.tsx
@@ -1,58 +1,61 @@
 import { JobListing } from "../data/job_listing";
 
 export function getDummyJobListings(): JobListing[] {
-  const dummyListings: JobListing[] = [];
+    const dummyListings: JobListing[] = [];
 
-  dummyListings.push({
-    company: "Penobscot Indian Nation",
-    title: "Information Technology Manager",
-    description:
-      "This Information Technology Manger is responsible for the overall planning, organization, and execution of all information technology within the Penobscot Nation. The position will provide and support the maintenance of existing applications and development of new technical solutions for the organization.",
-    criteria: [
-        {
-            field: "Location",
-            value: "Indian Island, ME 04468"
-        },
-        {
-            field: "Employment Type",
-            value: "Full-Time"
-        }
-    ]
-  });
+    dummyListings.push({
+        id: -1,
+        company: "Penobscot Indian Nation",
+        title: "Information Technology Manager",
+        description:
+            "This Information Technology Manger is responsible for the overall planning, organization, and execution of all information technology within the Penobscot Nation. The position will provide and support the maintenance of existing applications and development of new technical solutions for the organization.",
+        criteria: [
+            {
+                field: "Location",
+                value: "Indian Island, ME 04468",
+            },
+            {
+                field: "Employment Type",
+                value: "Full-Time",
+            },
+        ],
+    });
 
-  dummyListings.push({
-    company: "VERSANT POWER",
-    title: "IT ANALYST I",
-    description:
-      "The IT Analyst I is an entry-level technical position responsible for providing technology support, triage, configuration, testing and maintenance for the specified applications or services to the designated business owners within Versant Power.",
-    criteria: [
-        {
-            field: "Location",
-            value: "Bangor, ME 04401"
-        },
-        {
-            field: "Employment Type",
-            value: "Full-Time"
-        }
-    ]
-  });
+    dummyListings.push({
+        id: -2,
+        company: "VERSANT POWER",
+        title: "IT ANALYST I",
+        description:
+            "The IT Analyst I is an entry-level technical position responsible for providing technology support, triage, configuration, testing and maintenance for the specified applications or services to the designated business owners within Versant Power.",
+        criteria: [
+            {
+                field: "Location",
+                value: "Bangor, ME 04401",
+            },
+            {
+                field: "Employment Type",
+                value: "Full-Time",
+            },
+        ],
+    });
 
-  dummyListings.push({
-    company: "Wabanaki Public Health and Wellness",
-    title: "Client Computer Support Specialist",
-    description:
-      "The Computer Client Support Specialist provides technical support and assistance to computer users to include triage, ticket assignment, tier I issue resolution, account management, and systems monitoring. The individual also provides accurate and efficient tier I support for workstations and peripherals issues; recommends hardware; and schedules, receives, stores and distributes software, hardware and equipment according to company policy & procedures and asset tracking.",
-    criteria: [
-        {
-            field: "Location",
-            value: "Bangor, ME 04401"
-        },
-        {
-            field: "Employment Type",
-            value: "Full-Time"
-        }
-    ]
-  });
+    dummyListings.push({
+        id: -3,
+        company: "Wabanaki Public Health and Wellness",
+        title: "Client Computer Support Specialist",
+        description:
+            "The Computer Client Support Specialist provides technical support and assistance to computer users to include triage, ticket assignment, tier I issue resolution, account management, and systems monitoring. The individual also provides accurate and efficient tier I support for workstations and peripherals issues; recommends hardware; and schedules, receives, stores and distributes software, hardware and equipment according to company policy & procedures and asset tracking.",
+        criteria: [
+            {
+                field: "Location",
+                value: "Bangor, ME 04401",
+            },
+            {
+                field: "Employment Type",
+                value: "Full-Time",
+            },
+        ],
+    });
 
-  return dummyListings;
+    return dummyListings;
 }

--- a/src/pages/ListingPage.tsx
+++ b/src/pages/ListingPage.tsx
@@ -1,0 +1,35 @@
+import { useParams } from "react-router-dom";
+import { getDummyJobListings } from "../dummy/job_listing";
+import { JobCriteriaItem, JobListing } from "../data/job_listing";
+import { Col, Row } from "react-bootstrap";
+
+export function ListingPage(): JSX.Element {
+    const params = useParams();
+    const listingId = Number(params.listingId);
+
+    const jobListing = getDummyJobListings().find(
+        (value: JobListing): boolean => value.id === listingId
+    );
+    // TODO pull listings from firebase
+    if (jobListing === undefined) {
+        return <div>Not Found.</div>;
+    }
+
+    return (
+        <div>
+            <h1>{jobListing.company}</h1>
+            <h2>{jobListing.title}</h2>
+            <p>{jobListing.description}</p>
+            {jobListing.criteria.map(
+                (criteria: JobCriteriaItem): JSX.Element => {
+                    return (
+                        <Row>
+                            <Col>{criteria.field}</Col>
+                            <Col>{criteria.value}</Col>
+                        </Row>
+                    );
+                }
+            )}
+        </div>
+    );
+}

--- a/src/tests/login.test.tsx
+++ b/src/tests/login.test.tsx
@@ -5,53 +5,53 @@ import { LoginPage } from "../pages/LoginPage";
 import userEvent from "@testing-library/user-event";
 
 describe("Simple tests for login page", () => {
-  test("Login button is present", () => {
-    render(<App />);
+    test("Login button is present", () => {
+        render(<App />);
 
-    const loginButton = screen.getByRole("button", { name: "Login" });
+        const loginButton = screen.getByRole("button", { name: "Login" });
 
-    expect(loginButton).toBeInTheDocument();
-  });
-
-  test("Login button redirects to the login page", () => {
-    render(<App />);
-
-    const loginButton = screen.getByRole("button", { name: "Login" });
-    act(() => {
-      loginButton.click();
+        expect(loginButton).toBeInTheDocument();
     });
 
-    expect(document.location.pathname).toEqual("/Login");
-  });
+    test("Login button redirects to the login page", () => {
+        render(<App />);
 
-  test("Login page displays a form for email and password", () => {
-    render(<LoginPage />);
+        const loginButton = screen.getByRole("button", { name: "Login" });
+        act(() => {
+            loginButton.click();
+        });
 
-    const emailBox = screen.getByPlaceholderText("Email");
-    const passwordBox = screen.getByPlaceholderText("Password");
-
-    expect(emailBox).toBeInTheDocument();
-    expect(passwordBox).toBeInTheDocument();
-  });
-
-  test("Login page allows for inputting of both email and password", () => {
-    const [exampleEmail, examplePassword] = [
-      "example@example.com",
-      "examplePassword",
-    ];
-
-    render(<LoginPage />);
-
-    const emailBox = screen.getByPlaceholderText("Email");
-    const passwordBox = screen.getByPlaceholderText("Password");
-
-    // eslint-disable-next-line testing-library/no-unnecessary-act
-    act(() => {
-      userEvent.type(emailBox, exampleEmail);
-      userEvent.type(passwordBox, examplePassword);
+        expect(document.location.pathname).toEqual("/login");
     });
 
-    expect(emailBox).toHaveValue(exampleEmail);
-    expect(passwordBox).toHaveValue(examplePassword);
-  });
+    test("Login page displays a form for email and password", () => {
+        render(<LoginPage />);
+
+        const emailBox = screen.getByPlaceholderText("Email");
+        const passwordBox = screen.getByPlaceholderText("Password");
+
+        expect(emailBox).toBeInTheDocument();
+        expect(passwordBox).toBeInTheDocument();
+    });
+
+    test("Login page allows for inputting of both email and password", () => {
+        const [exampleEmail, examplePassword] = [
+            "example@example.com",
+            "examplePassword",
+        ];
+
+        render(<LoginPage />);
+
+        const emailBox = screen.getByPlaceholderText("Email");
+        const passwordBox = screen.getByPlaceholderText("Password");
+
+        // eslint-disable-next-line testing-library/no-unnecessary-act
+        act(() => {
+            userEvent.type(emailBox, exampleEmail);
+            userEvent.type(passwordBox, examplePassword);
+        });
+
+        expect(emailBox).toHaveValue(exampleEmail);
+        expect(passwordBox).toHaveValue(examplePassword);
+    });
 });


### PR DESCRIPTION
Added a basic listing router that works with the dummy data we have in the repo. It adds a page at "/listing/(id)" that grabs the listing with the set ID and renders the details of it.